### PR TITLE
Backported handling of empty and too large indel results from 2.5.0.

### DIFF
--- a/IndelCallingWorkflow.iml
+++ b/IndelCallingWorkflow.iml
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="Python" name="Python">
-      <configuration sdkName="Python 2.7 (AlignmentAndQCWorkflows)" />
+      <configuration sdkName="Python 3.7 (wesnake)" />
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/resources/analysisTools" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/resources/configurationFiles" type="java-resource" />
-      <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module" module-name="PluginBase_1.2.1" />
-    <orderEntry type="module" module-name="Roddy" />
-    <orderEntry type="module" module-name="RoddyToolLib" />
-    <orderEntry type="library" name="Gradle: org.codehaus.groovy:groovy-all:2.4.9" level="project" />
-    <orderEntry type="library" name="R User Library" level="project" />
-    <orderEntry type="library" name="R Skeletons" level="application" />
-    <orderEntry type="library" name="Python 2.7 (AlignmentAndQCWorkflows) interpreter library" level="application" />
     <orderEntry type="module" module-name="COWorkflowsBasePlugin_1.4.1" />
+    <orderEntry type="module" module-name="DefaultPlugin_1.2.2" />
+    <orderEntry type="module" module-name="PluginBase_1.2.1" />
+    <orderEntry type="module" module-name="Roddy.main" />
+    <orderEntry type="library" name="Python 3.7 (wesnake) interpreter library" level="application" />
+    <orderEntry type="module" module-name="RoddyToolLib.main" />
+    <orderEntry type="library" name="Gradle: org.codehaus.groovy:groovy-all:2.4.9" level="project" />
   </component>
 </module>

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ TBD
 
 # Changelist
 
+* Version update to 2.2.1
+
+  * Stability improvement Perl to protect against I/O errors
+  * Write text PDf upon empty and too many indels
+
 * Version update to 2.2.0
 
   * Upgrade from [COWorkflowsBasePlugin](https://github.com/DKFZ-ODCF/COWorkflowsBasePlugin) 1.1.0 to 1.4.1

--- a/resources/analysisTools/indelCallingWorkflow/filter_vcf.sh
+++ b/resources/analysisTools/indelCallingWorkflow/filter_vcf.sh
@@ -71,20 +71,44 @@ ${PERL_BINARY} ${TOOL_PLATYPUS_INDEL_EXTRACTOR} --bgzip=${BGZIP_BINARY} --tabix=
 
 [[ ! -d ${screenshot_dir} ]] && mkdir ${screenshot_dir} && cd ${screenshot_dir}
 
-functional_var_count=`cat ${somatic_functional_indel_vcf} | wc -l | cut -f1 -d " "`
+functional_var_count=$(cat ${somatic_functional_indel_vcf} | tail -n +2 | wc -l | cut -f1 -d " ")
+if [[ $functional_var_count -eq 0 ]]; then
+    printf "WARNING: No functional variants present in ${somatic_functional_indel_vcf}\n"
+    $RSCRIPT_BINARY "$TOOL_TEXT_PDF" "WARNING: No functional variants." \
+        > "$combined_screen_shots"
 
-if [[ $functional_var_count -le $MAX_VARIANT_SCREENSHOTS ]]
-then
+elif [[ $functional_var_count -le $MAX_VARIANT_SCREENSHOTS ]]; then
+    if [[ "$isControlWorkflow" == true ]]; then
+        $PYTHON_BINARY "$TOOL_SCREENSHOT" \
+            --vcf="$somatic_functional_indel_vcf" \
+            --control="$FILENAME_CONTROL_BAM" \
+            --tumor="$FILENAME_TUMOR_BAM" \
+            --ref="$REFERENCE_GENOME" \
+            --prefix="$VCF_SCREENSHOTS_PREFIX" \
+            --window="$WINDOW_SIZE" \
+            --annotations="$REPEAT_MASKER" \
+            --samtoolsbin="$SAMTOOLS_BINARY" \
+            --tabixbin="$TABIX_BINARY"
+    fi
+    if [[ "$isNoControlWorkflow" == true ]]; then
+        $PYTHON_BINARY "$TOOL_SCREENSHOT" \
+            --vcf="$somatic_functional_indel_vcf" \
+            --tumor="$FILENAME_TUMOR_BAM" \
+            --ref="$REFERENCE_GENOME" \
+            --prefix="$VCF_SCREENSHOTS_PREFIX" \
+            --window="$WINDOW_SIZE" \
+            --annotations="$REPEAT_MASKER" \
+            --samtoolsbin="$SAMTOOLS_BINARY" \
+            --tabixbin="$TABIX_BINARY"
+    fi
+    pngs=(`ls *.pdf`)
+    sorted=$(printf "%s\n" ${pngs[@]} | sort -k1,1V)
 
-  [[ "${isControlWorkflow}" == true ]] && ${PYTHON_BINARY} ${TOOL_SCREENSHOT} --vcf=${somatic_functional_indel_vcf} --control=${FILENAME_CONTROL_BAM} --tumor=${FILENAME_TUMOR_BAM} --ref=${REFERENCE_GENOME} --prefix=${VCF_SCREENSHOTS_PREFIX} --window=${WINDOW_SIZE} --annotations=${REPEAT_MASKER} --samtoolsbin=${SAMTOOLS_BINARY} --tabixbin=${TABIX_BINARY}
-  [[ "${isNoControlWorkflow}" == true ]] && ${PYTHON_BINARY} ${TOOL_SCREENSHOT} --vcf=${somatic_functional_indel_vcf} --tumor=${FILENAME_TUMOR_BAM} --ref=${REFERENCE_GENOME} --prefix=${VCF_SCREENSHOTS_PREFIX} --window=${WINDOW_SIZE} --annotations=${REPEAT_MASKER} --samtoolsbin=${SAMTOOLS_BINARY} --tabixbin=${TABIX_BINARY}
-
-  pngs=(`ls *.pdf`)
-  sorted=$(printf "%s\n" ${pngs[@]}|sort -k1,1V)
-
-  ${GHOSTSCRIPT_BINARY} -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile=${combined_screen_shots} ${sorted}
+    ${GHOSTSCRIPT_BINARY} -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile="$combined_screen_shots" "$sorted"
 else
-  printf "WARNINGS: No screenshots done, more than $MAX_VARIANT_SCREENSHOTS (cvalue - MAX_VARIANT_SCREENSHOTS) functional variants present in ${somatic_functional_indel_vcf} \n"
+  printf "WARNING: No screenshots done, more than $MAX_VARIANT_SCREENSHOTS (cvalue - MAX_VARIANT_SCREENSHOTS) functional variants present in ${somatic_functional_indel_vcf}\n"
+  $RSCRIPT_BINARY "$TOOL_TEXT_PDF" "WARNING: No screenshots done. More than $MAX_VARIANT_SCREENSHOTS functional variants." \
+        > "$combined_screen_shots"
 fi
 
 #### Indel QC json file

--- a/resources/analysisTools/indelCallingWorkflow/textPdf.R
+++ b/resources/analysisTools/indelCallingWorkflow/textPdf.R
@@ -1,0 +1,15 @@
+#!/usr/bin/env Rscript
+
+args <- commandArgs(trailingOnly=TRUE)
+if (length(args) == 0) {
+    text <- ""
+} else {
+    text <- args[1]
+}
+
+write(text, stdout())
+
+pdf("/dev/stdout", height=3, width=6)
+plot.new()
+mtext(text)
+ignore <- dev.off()

--- a/resources/configurationFiles/analysisIndelCalling.xml
+++ b/resources/configurationFiles/analysisIndelCalling.xml
@@ -195,6 +195,7 @@
         <tool name="screenshot" value="visualize.py" basepath="indelCallingWorkflow"/>
         <tool name="vcfFilterByCrit" value="vcf_filter_by_crit.py" basepath="indelCallingWorkflow"/>
         <tool name="platypusIndelJson" value="indel_json_v1.0.pl" basepath="indelCallingWorkflow"/>
+        <tool name="textPdf" value="textPdf.R" basepath="indelCallingWorkflow"/>
 
         <!--## SwapChecker -->
         <tool name="checkSampleSwapScript" value="checkSampleSwap_TiN.pl" basepath="indelCallingWorkflow"/>


### PR DESCRIPTION
Versions 2.4.0+ handle empty Indel results as well as too many Indels but still writing PDFs. This PR backports these changes to version 2.2.0. The idea is to have a version 2.2.1 on a release branch. 

This does not backport all stability and empty-file support features, yet, though. Good candidates for further backports could be `checkSampleSwap.pl` and `checkSampleSwap.sh`. Tell me, if you are o.k. with including these changes in this PR.