### PR TITLE
Changelog update

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ TBD
 
 # Changelist
 
-Currently, the following versions are run in our production system. In all of them a bug that was introduced in version 1.0.167 is fixed that could result in swapped column labels. If Note that versions 2.0, 2.2, and 2.4 are not mutually exchangeable, despite having the same major version number.
+Currently, the following versions are run in our production system. In all of them a bug that was introduced in version 1.0.167 is fixed that could result in swapped column labels. Note that versions 2.0, 2.2, and 2.4 are not mutually exchangeable, despite having the same major version number. The versioning did not follow the [SemVer 2.0](https://semver.org) scheme.
 
-* Version update to 3.1.0 (2.6.0-deprecated)
+The currently supported branches are 3 (master), 2.4.1, 2.2, 2.0.0-1, and 1.2.177. Only on master new features are implemented, so the other branches are only for bugfixes. The most recent commit on each of these branches is listed at the top:
+
+* Version update to 3.1.0 (2.6.0-deprecated, master)
 
   - Minor: Bugfix: Fix of column swap bug introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
   - Minor: Added `--skip_order_tag` to skip the above, if users manually verified the genotype column order

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ A Platypus-based insertion/deletion-detection workflow with extensive quality co
 
 > <table><tr><td><a href="https://www.denbi.de/"><img src="docs/images/denbi.png" alt="de.NBI logo" width="300" align="left"></a></td><td><strong>Your opinion matters!</strong> The development of this workflow is supported by the <a href="https://www.denbi.de/">German Network for Bioinformatic Infrastructure (de.NBI)</a>. By completing <a href="https://www.surveymonkey.de/r/denbi-service?sc=hd-hub&tool=IndelCallingWorkflow">this very short (30-60 seconds) survey</a> you support our efforts to improve this tool.</td></tr></table>
 
+## Citing
+
+The Indel workflow was in the pan-cancer analysis of whole genomes (PCAWG) and can be cited with the following publication:
+
+* Pan-cancer analysis of whole genomes.<br>
+  The ICGC/TCGA Pan-Cancer Analysis of Whole Genomes Consortium.<br>
+  Nature volume 578, pages 82–93 (2020).<br>
+  DOI [10.1038/s41586-020-1969-6](https://doi.org/10.1038/s41586-020-1969-6)
+
+Containers are available in [Dockstore](https://dockstore.org/containers/quay.io/pancancer/pcawg-dkfz-workflow)
+
+Furthermore, the workflow is regularly used at the DKFZ throug the automation system [One-Touch Pipeline](https://gitlab.com/one-touch-pipeline/otp):
+
+* OTP: An automatized system for managing and processing NGS data.<br>
+  Eva Reisinger, Lena Genthner, Jules Kerssemakers, Philip Kenschea, Stefan Borufka, Alke Jugold, Andreas Kling, Manuel Prinz, Ingrid Scholz, Gideon Zipprich, Roland Eils, Christian Lawerenz, Jürgen Eils.<br>
+   Journal of Biotechnology, volume 261, pages 53-62 (2017).<br>
+   DOI: [10.1016/j.jbiotec.2017.08.006](https://doi.org/10.1016/j.jbiotec.2017.08.006)
+
 ## Software Requirements
 
 Please refer to the Roddy [website](https://github.com/eilslabs/Roddy) for instructions on how to install Roddy.

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ The following are older versions of the workflow on which no further development
 
 * Version update to 1.0.167 (Column bug 1.0.167)
 
-  - Note that commit e8d8fc27 _introduced_ a bug that caused the labels of the control and tumor genotype columns (10 & 11) to be swapped into alphabetical order, but left the data in the original order. The root cause of the bug is that Platypus reorders these columns alphabetically, but that this was not accounted for in the workflow code. The bug has no influence on the list of reported indels. This means that all somatic indels are correct. Only samples in which the alphabetical order of the tumor sample is before that of the control sample (e.g. cell_line < control).
+  - Note that commit e8d8fc27 _introduced_ a bug that caused the labels of the control and tumor genotype columns (10 & 11) to be swapped into alphabetical order, but left the data in the original order. The root cause of the bug is that Platypus reorders these columns alphabetically, but that this was not accounted for in the workflow code. The bug has no influence on the list of reported indels. This means that all somatic indels are correct. Only sample pairs are affected for which the alphabetical order of the tumor sample is before that of the control sample (e.g. cell_line < control).
 
 * Version update to 1.0.161
 

--- a/README.md
+++ b/README.md
@@ -221,8 +221,11 @@ The following are older versions of the workflow on which no further development
 
 * Version update to 1.0.176-10 (=1.0.177-1) ([Column bug](#column-bug))
 
-  - Added right and bottom border features to `TiN_canopyBasedClustering.R`
-  - Version is not backwards compatible
+  - Major: Added a method based on maximum Control_AF to remove unusual cluster.
+  - Major: Increased the number of iterations to 100 (from 50) in the EM step. TiNDA rescue clusters will not be same.
+  - Minor: Added a polygon shape to the TiNDA plot. Plots will look different.
+  - Minor: Parametrised the right and left threshold that defines the border for TiNDA cluster selection, but by default use the same values as before.
+  - Patch: Fixed the bugs in the bash sanity checks.
 
 * Version update to 1.0.176-9 (=1.0.177) ([Column bug](#column-bug))
 
@@ -242,7 +245,9 @@ The following are older versions of the workflow on which no further development
 
 * Version update to 1.0.167 (<a id="column-bug"></a>Column bug)
 
-  - Note that commit e8d8fc27 _introduced_ a bug that caused the labels of the control and tumor genotype columns (10 & 11) to be swapped into alphabetical order, but left the data in the original order. The root cause of the bug is that Platypus reorders these columns alphabetically, but that this was not accounted for in the workflow code. The bug has no influence on the list of reported indels. This means that all somatic indels are correct. Only sample pairs are affected for which the alphabetical order of the tumor sample is before that of the control sample (e.g. cell_line < control).
+  - Background: Platypus always orders the columns alpha-numerically. In our data, usually sample ID for the control is alpha-numerically smaller than that for the tumor, e.g., control/normal/blood < tumor/metastasis. Only for the sample pairs where tumor ID comes before the control (e.g. 'cell_line' < 'control'), the tumor genotype columns come before the control column in the raw VCF. This column swap was accounted for in the workflow code while detecting the somatic variants and control and, if needed, it swapped the columns. 
+    Bug: The commit e8d8fc27, which replaced the Perl script with the Python script, introduced a bug that replaced changed the names of the columns in the 10th & 11th columns with the unsorted labels, but left the data in the order created by Platypus.
+    > NOTE: This bug has no influence on the list of reported indels, and all somatic indels are correct. Only the genotype data are in the wrong columns.
 
 * Version update to 1.0.161
 

--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ The following are older versions of the workflow on which no further development
 
 * Version update to 1.0.167 (<a id="column-bug"></a>Column bug)
 
-  - Background: Platypus always orders the columns alpha-numerically. In our data, usually sample ID for the control is alpha-numerically smaller than that for the tumor, e.g., control/normal/blood < tumor/metastasis. Only for the sample pairs where tumor ID comes before the control (e.g. 'cell_line' < 'control'), the tumor genotype columns come before the control column in the raw VCF. This column swap was accounted for in the workflow code while detecting the somatic variants and control and, if needed, it swapped the columns. 
-    Bug: The commit e8d8fc27, which replaced the Perl script with the Python script, introduced a bug that replaced the names of the columns in the 10th & 11th columns with the unsorted labels, but left the data in the order created by Platypus. Consequently, if Platypus reordered the columns and the script reused the unordered labels, the labels are swapped.
+  - Background: Platypus always orders the columns alpha-numerically. In our data, usually sample ID for the control is alpha-numerically smaller than that for the tumor, e.g., control/normal/blood < tumor/metastasis. Only for the sample pairs where tumor ID comes before the control (e.g. 'cell_line' < 'control'), the tumor genotype columns come before the control column in the raw VCF. This column swap was accounted for in the workflow code while detecting the somatic variants: if needed, the columns were swapped. 
+    Bug: The commit e8d8fc27, which replaced the Perl script with the Python script, introduced a bug that replaced the names of the columns in the 10th & 11th columns with the unsorted labels, but left the data in the order created by Platypus.
     > NOTE: This bug has no influence on the list of reported indels, and all somatic indels are correct. Only the genotype data are in the wrong columns.
 
 * Version update to 1.0.161

--- a/README.md
+++ b/README.md
@@ -65,13 +65,17 @@ TBD
 
 # Changelist
 
-Currently, the following versions are run in our production system. In all of them a bug that was introduced in version 1.0.167 is fixed that could result in swapped column labels. Note that versions 2.0, 2.2, and 2.4 are not mutually exchangeable, despite having the same major version number. The versioning did not follow the [SemVer 2.0](https://semver.org) scheme.
+Currently, the following versions are run in our production system. In all of them a bug that was introduced in version 1.0.167 is fixed that could result in swapped column labels. 
 
-The currently supported branches are 3 (master), 2.4.1, 2.2, 2.0.0-1, and 1.2.177. Only on master new features are implemented, so the other branches are only for bugfixes. The most recent commit on each of these branches is listed at the top:
+The currently supported branches are 3 (master), 2.4.1, 2.2, 2.0.0-1, and 1.2.177. Unfortunately, the results from these branches are not compatible with each other. For larger studies you may want to use only versions that produce comparable results. 
+
+Note that only on `master` new features are implemented, so the other branches are only for bugfixes. 
+
+Here is a list of the most recent release on each of supported branches:
 
 * Version update to 3.1.0 (2.6.0-deprecated, master)
 
-  - Minor: Bugfix: Fix of column swap bug introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
+  - Minor: Bugfix: Fix of column swap [bug](#column-bug) introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
   - Minor: Added `--skip_order_tag` to skip the above, if users manually verified the genotype column order
   - Patch: Crash the workflow if genotype column names could not be verified through BAM SM tags
   - Patch: Crash the workflow if more than two samples are present in the raw VCF file. This could be due to multiple RG tags.
@@ -79,71 +83,71 @@ The currently supported branches are 3 (master), 2.4.1, 2.2, 2.0.0-1, and 1.2.17
 
 * Version update to 2.4.1-1 (ReleaseBranch_2.4.1)
 
-  - Bugfix: Fix of column swap bug introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
+  - Bugfix: Fix of column swap [bug](#column-bug) introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
 
 * Version update to 2.2.2 (ReleaseBranch_2.2)
 
-  - Bugfix: Fix of column swap bug introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
+  - Bugfix: Fix of column swap [bug](#column-bug) introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
 
 * Version update to 2.0.0-101 (ReleaseBranch_2.0.0-1)
 
-  - Bugfix: Fix of column swap bug introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
+  - Bugfix: Fix of column swap [bug](#column-bug) introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
 
 * Version update to 1.2.177-601 (ReleaseBranch_1.2.177-6)
 
-  - Bugfix: Fix of column swap bug introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
+  - Bugfix: Fix of column swap [bug](#column-bug) introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
 
 
 The following are older versions of the workflow on which no further development will take place.
 
 
-* Version update to 3.0.0 (2.5.0-deprecated) (Column bug since 1.0.167)
+* Version update to 3.0.0 (2.5.0-deprecated) ([Column bug](#column-bug))
 
   - Major: Added a local control generated from ~1k WES samples
   - Deprecated version-tag 2.5.0 because this is actually a major-level change.
 
-* Version update to 2.4.3 (Column bug since 1.0.167)
+* Version update to 2.4.3 ([Column bug](#column-bug))
 
   - Bugfix: `platypusIndelAnnotation.sh` now checks output of annovar execution for error code != 0. Without this the workflow will continue even if annovar throws an exception.
 
-* Version update to 2.4.2 (Column bug since 1.0.167)
+* Version update to 2.4.2 ([Column bug](#column-bug))
 
   - Fixed missed annotations due to unsorted VCF
   
-* Version update to 2.4.1 (Column bug since 1.0.167)
+* Version update to 2.4.1 ([Column bug](#column-bug))
 
   - Create __non-empty__ sample swap JSON even if less than 50 germline variants
   - More error-robust IO in sample swap TINDA Perl script
 
-* Version update to 2.4.0 (Column bug since 1.0.167)
+* Version update to 2.4.0 ([Column bug](#column-bug))
 
   - Bugfix: Casting error in canopy-based clustering R code
   - Bugfix: Create warning PDF with text if number of to-be-merged PDFs is too large or zero, plus fix one-off bug
   - Exit 0 instead of != 0, if less then 50 germline variants
 
-* Version update 2.3.0 (Column bug since 1.0.167)
+* Version update 2.3.0 ([Column bug](#column-bug))
 
   - Added `isNoControlWorkflow` variable and make FILTER_database work with it
   - Removed usage of ExAC from filtering, gnomAD includes ExAC
   - Report only exact matches for database annotation
   
-* Version update to 2.2.1 (Column bug since 1.0.167)
+* Version update to 2.2.1 ([Column bug](#column-bug))
 
   - Stability improvement Perl to protect against I/O errors
   - Write text PDF upon empty and too many indels
 
-* Version update to 2.2.0 (Column bug since 1.0.167)
+* Version update to 2.2.0 ([Column bug](#column-bug))
 
   - Upgrade from [COWorkflowsBasePlugin](https://github.com/DKFZ-ODCF/COWorkflowsBasePlugin) 1.1.0 to 1.4.1
 
-* Version update to 2.1.0-2 (Column bug since 1.0.167)
+* Version update to 2.1.0-2 ([Column bug](#column-bug))
 
   - Fixed FILENAME_ parameter
   - Executability check for `REFERENCE_GENOME` variable (file accessible from submission host)
   - Fixed reported version.
   - Code cleanup in `annotate_vcf.pl`
 
-* Version update to 2.1.0-1 (Column bug since 1.0.167)
+* Version update to 2.1.0-1 ([Column bug](#column-bug))
 
   - Added gnomAD exomes
   - Added local controls
@@ -151,15 +155,15 @@ The following are older versions of the workflow on which no further development
   - Check REF_genome for BAM files
   - Check BAM file readability
 
-* Version update to 2.0.0-2 (Column bug since 1.0.167)
+* Version update to 2.0.0-2 ([Column bug](#column-bug))
 
   - Restricting screenshot generation to 100
 
-* Version update to 2.0.0-1 (Column bug since 1.0.167)
+* Version update to 2.0.0-1 ([Column bug](#column-bug))
 
   - README update
   
-* Version update to 2.0.0 (Column bug since 1.0.167)
+* Version update to 2.0.0 ([Column bug](#column-bug))
 
   - TiNDA workflow was updated
     - Two local controls are removed, and a new local control created from ~3000 WGS platypus variant calls were added.
@@ -169,32 +173,32 @@ The following are older versions of the workflow on which no further development
     - Temporary TiNDA files are cleaned up
     - TiNDA will stop if there are less than 50 rare germline variants
 
-* Version update to 1.3.0 (Column bug since 1.0.167)
+* Version update to 1.3.0 ([Column bug](#column-bug))
 
   - Added `tumorSample` and `controlSample` variables to job environments. These can also be used in output file paths.
 
-* Version update to 1.2.178 (Column bug since 1.0.167)
+* Version update to 1.2.178 ([Column bug](#column-bug))
 
   - Including gnomAD exomes and genomes for nocontrol workflow filtering.
   - Adding gnomAD files for no-control workflow.
   - Updated from COWorkflowsBasePlugin:1.0.3 to COWorkflowsBasePlugin:1.1.0.
 
-* Version update to 1.2.177-8 (=1.2.182) (Column bug since 1.0.167)
+* Version update to 1.2.177-8 (=1.2.182) ([Column bug](#column-bug))
 
   - major: Changed `GERMLINE_AVAILABLE` with allowed values 0 and 1 to `isNoControlWorkflow` with allowed values "false" and "true".
   - minor: Update to from COWorkflows:1.2.59 to COWorkflowsBasePlugin:1.0.3.
   - minor: Added writing TiN classification to the VCF file.
   - Note that the version may report itself as 1.2.182 according to the `versionInfo.txt`.
 
-* Version update to 1.2.177-7 (Column bug since 1.0.167)
+* Version update to 1.2.177-7 ([Column bug](#column-bug))
 
   - patch: Fix problem with dealing with empty result files in `indelCalling.sh`.
   
-* Version update to 1.2.177-6 (Column bug since 1.0.167)
+* Version update to 1.2.177-6 ([Column bug](#column-bug))
 
   - Removed a `umask` from `checkSampleSwap_TiN.sh`.
 
-* Version update to 1.2.177-5 (Column bug since 1.0.167)
+* Version update to 1.2.177-5 ([Column bug](#column-bug))
 
   - Platypus update 0.8.1 to 0.8.1.1 (this only fixes the reported Platypus version number in the VCF)
   - Added conda environment
@@ -202,7 +206,7 @@ The following are older versions of the workflow on which no further development
   - Neutral refactoring in `indelCalling.sh`
   - Bugfix: JSON syntax for "file"
 
-* Version update to 1.2.177-4 (includes development versions 1.2.177-1 to -3) (Column bug since 1.0.167)
+* Version update to 1.2.177-4 (includes development versions 1.2.177-1 to -3) ([Column bug](#column-bug))
 
   - Roddy 3.0 support
   - Updated COWorkflows base plugin from 1.2.59 to 1.2.76
@@ -210,31 +214,33 @@ The following are older versions of the workflow on which no further development
   - Bugfix in `indel_extractor_v1.pl` concerning ncRNA_exonic and ncRNA_splicing annotations for somatic calls.
   - Added `runTinda` cvalue
 
-* Version update to 1.0.177-2 (Column bug since 1.0.167)
+* Version update to 1.0.177-2 ([Column bug](#column-bug))
 
   - Bugfix ncRNA file
   - Allow toggling on/off of Tinda
 
-* Version update to 1.0.176-10 (=1.0.177-1) (Column bug since 1.0.167)
+* Version update to 1.0.176-10 (=1.0.177-1) ([Column bug](#column-bug))
 
   - Added right and bottom border features to `TiN_canopyBasedClustering.R`
   - Version is not backwards compatible
 
-* Version update to 1.0.176-9 (=1.0.177) (Column bug since 1.0.167)
+* Version update to 1.0.176-9 (=1.0.177) ([Column bug](#column-bug))
 
   - Fix of a bug affecting versions 1.0.176 to 1.0.176-8 that results in higher false positive rate.
 
-* Version update to 1.0.176 (Column bug since 1.0.167)
+> NOTE: Refrain from using versions 1.0.176 through 1.0.176-8. They are affected by a bug that increases the false positive rate.
+
+* Version update to 1.0.176 ([Column bug](#column-bug))
 
   - SNVs calling made default.
   - Swapchecker - checks for tumor/control swap from the same PID.
   - TiNDA - Tumor in normal detection analysis, using Canopy's EM-clustering algorithm.
 
-* Version update to 1.0.168 (Column bug since 1.0.167)
+* Version update to 1.0.168 ([Column bug](#column-bug))
 
   - Further checks for the platypus indel calling step are introduced. A zgrep will be performed, together with a linecount to see if there are any faulty lines in the raw vcf file.
 
-* Version update to 1.0.167 (Column bug 1.0.167)
+* Version update to 1.0.167 (<a id="column-bug"></a>Column bug)
 
   - Note that commit e8d8fc27 _introduced_ a bug that caused the labels of the control and tumor genotype columns (10 & 11) to be swapped into alphabetical order, but left the data in the original order. The root cause of the bug is that Platypus reorders these columns alphabetically, but that this was not accounted for in the workflow code. The bug has no influence on the list of reported indels. This means that all somatic indels are correct. Only sample pairs are affected for which the alphabetical order of the tumor sample is before that of the control sample (e.g. cell_line < control).
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Most bioinformatic software required for this workflow is available in Conda, ho
 
 ### Conda
 
-The workflow contains a description of a [Conda](https://conda.io/docs/) environment. A number of Conda packages from [BioConda](https://bioconda.github.io/index.html) are required. You should set up the Conda environment at a centralized position available from all compute hosts. 
+The workflow contains a description of a [Conda](https://conda.io/docs/) environment. A number of Conda packages from [BioConda](https://bioconda.github.io/index.html) are required. You should set up the Conda environment at a centralized position available from all compute hosts.
 
 First install the BioConda channels:
 ```
@@ -65,69 +65,83 @@ TBD
 
 # Changelist
 
-* Version update to 3.1.0 (2.6.0-deprecated) 
+Currently, the following versions are run in our production system. In all of them a bug that was introduced in version 1.0.167 is fixed that could result in swapped column labels. If Note that versions 2.0, 2.2, and 2.4 are not mutually exchangeable, despite having the same major version number.
+
+* Version update to 3.1.0 (2.6.0-deprecated)
 
   - Minor: Bugfix: Fix of column swap bug introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
-  - Minor: Added `--skip_order_tag` to skip the above if users manually verified the genotype column order
+  - Minor: Added `--skip_order_tag` to skip the above, if users manually verified the genotype column order
   - Patch: Crash the workflow if genotype column names could not be verified through BAM SM tags
   - Patch: Crash the workflow if more than two samples are present in the raw VCF file. This could be due to multiple RG tags.
-  - Deprecated 2.6.0 because of the major-level change in 2.5.0-deprecated/3.0.0.
-
-* Version update to 3.0.0 (2.5.0-deprecated)
-
-  - Major: Added a local control generated from ~1k WES samples
-  - Deprecated 2.5.0 because this is actually a major-level change.
-  
-* Version update to 2.4.3
-
-  - Bugfix: `platypusIndelAnnotation.sh` now checks output of annovar execution for error code != 0. Without this the workflow will continue even if annovar throws an exception.
-
-* Version update to 2.4.2
-
-  - Fixed missed annotations due to unsorted VCF
+  - Deprecated version-tag 2.6.0 because of the major-level change in 2.5.0-deprecated/3.0.0
 
 * Version update to 2.4.1-1 (ReleaseBranch_2.4.1)
 
   - Bugfix: Fix of column swap bug introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
 
-* Version update to 2.4.1
-
-  - Create __non-empty__ sample swap JSON even if less than 50 germline variants
-  - More error-robust IO in sample swap TINDA Perl script
-
-* Version update to 2.4.0
-
-  - Bugfix: Casting error in canopy-based clustering R code
-  - Bugfix: Create warning PDF with text if number of to-be-merged PDFs is too large or zero, plus fix one-off bug
-  - Exit 0 instead of != 0, if less then 50 germline variants
- 
-* Version update 2.3.0
-
-  - Added `isNoControlWorkflow` variable and make FILTER_database work with it
-  - Removed usage of ExAC from filtering, gnomAD includes ExAC
-  - Report only exact matches for database annotation
-
 * Version update to 2.2.2 (ReleaseBranch_2.2)
 
   - Bugfix: Fix of column swap bug introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
 
-* Version update to 2.2.1 
- 
+* Version update to 2.0.0-101 (ReleaseBranch_2.0.0-1)
+
+  - Bugfix: Fix of column swap bug introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
+
+* Version update to 1.2.177-601 (ReleaseBranch_1.2.177-6)
+
+  - Bugfix: Fix of column swap bug introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
+
+
+The following are older versions of the workflow on which no further development will take place.
+
+
+* Version update to 3.0.0 (2.5.0-deprecated) (Bug since 1.0.167)
+
+  - Major: Added a local control generated from ~1k WES samples
+  - Deprecated version-tag 2.5.0 because this is actually a major-level change.
+
+* Version update to 2.4.3 (Bug since 1.0.167)
+
+  - Bugfix: `platypusIndelAnnotation.sh` now checks output of annovar execution for error code != 0. Without this the workflow will continue even if annovar throws an exception.
+
+* Version update to 2.4.2 (Bug since 1.0.167)
+
+  - Fixed missed annotations due to unsorted VCF
+  
+* Version update to 2.4.1 (Bug since 1.0.167)
+
+  - Create __non-empty__ sample swap JSON even if less than 50 germline variants
+  - More error-robust IO in sample swap TINDA Perl script
+
+* Version update to 2.4.0 (Bug since 1.0.167)
+
+  - Bugfix: Casting error in canopy-based clustering R code
+  - Bugfix: Create warning PDF with text if number of to-be-merged PDFs is too large or zero, plus fix one-off bug
+  - Exit 0 instead of != 0, if less then 50 germline variants
+
+* Version update 2.3.0 (Bug since 1.0.167)
+
+  - Added `isNoControlWorkflow` variable and make FILTER_database work with it
+  - Removed usage of ExAC from filtering, gnomAD includes ExAC
+  - Report only exact matches for database annotation
+  
+* Version update to 2.2.1 (Bug since 1.0.167)
+
   - Stability improvement Perl to protect against I/O errors
   - Write text PDf upon empty and too many indels
 
-* Version update to 2.2.0
+* Version update to 2.2.0 (Bug since 1.0.167)
 
   - Upgrade from [COWorkflowsBasePlugin](https://github.com/DKFZ-ODCF/COWorkflowsBasePlugin) 1.1.0 to 1.4.1
 
-* Version update to 2.1.0-2
+* Version update to 2.1.0-2 (Bug since 1.0.167)
 
   - Fixed FILENAME_ parameter
   - Executability check for `REFERENCE_GENOME` variable (file accessible from submission host)
   - Fixed reported version.
   - Code cleanup in `annotate_vcf.pl`
 
-* Version update to 2.1.0-1
+* Version update to 2.1.0-1 (Bug since 1.0.167)
 
   - Added gnomAD exomes
   - Added local controls
@@ -135,19 +149,15 @@ TBD
   - Check REF_genome for BAM files
   - Check BAM file readability
 
-* Version update to 2.0.0-2
+* Version update to 2.0.0-2 (Bug since 1.0.167)
 
   - Restricting screenshot generation to 100
-  
-* Version update to 2.0.0-1
+
+* Version update to 2.0.0-1 (Bug since 1.0.167)
 
   - README update
-
-* Version update to 2.0.0-101 (ReleaseBranch_2.0.0-1)
-
-  - Bugfix: Fix of column swap bug introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
   
-* Version update to 2.0.0
+* Version update to 2.0.0 (Bug since 1.0.167)
 
   - TiNDA workflow was updated
     - Two local controls are removed, and a new local control created from ~3000 WGS platypus variant calls were added.
@@ -157,30 +167,32 @@ TBD
     - Temporary TiNDA files are cleaned up
     - TiNDA will stop if there are less than 50 rare germline variants
 
-* Version update to 1.3.0
+* Version update to 1.3.0 (Bug since 1.0.167)
 
   - Added `tumorSample` and `controlSample` variables to job environments. These can also be used in output file paths.
 
-* Version update to 1.2.178
+* Version update to 1.2.178 (Bug since 1.0.167)
 
   - Including gnomAD exomes and genomes for nocontrol workflow filtering.
   - Adding gnomAD files for no-control workflow.
-  - Updating the COWorkflowsBasePlugin.
-  - Including gnomAD exomes and genomes for nocontrol workflow filtering
+  - Updated from COWorkflowsBasePlugin:1.0.3 to COWorkflowsBasePlugin:1.1.0.
 
-* Version update to 1.2.177-8
+* Version update to 1.2.177-8 (=1.2.182) (Bug since 1.0.167)
 
-* Version update to 1.2.177-7
+  - major: Changed `GERMLINE_AVAILABLE` with allowed values 0 and 1 to `isNoControlWorkflow` with allowed values "false" and "true".
+  - minor: Update to from COWorkflows:1.2.59 to COWorkflowsBasePlugin:1.0.3.
+  - minor: Added writing TiN classification to the VCF file.
+  - Note that the version may report itself as 1.2.182 according to the `versionInfo.txt`.
 
-* Version update to 1.2.177-601 (ReleaseBranch_1.2.177-6)
+* Version update to 1.2.177-7 (Bug since 1.0.167)
 
-  - Bugfix: Fix of column swap bug introduced before 1.0.167. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
+  - patch: Fix problem with dealing with empty result files in `indelCalling.sh`.
+  
+* Version update to 1.2.177-6 (Bug since 1.0.167)
 
-* Version update to 1.2.177-6
+  - Removed a `umask` from `checkSampleSwap_TiN.sh`.
 
-  - removed a `umask` from `checkSampleSwap_TiN.sh`
-
-* Version update to 1.2.177-5
+* Version update to 1.2.177-5 (Bug since 1.0.167)
 
   - Platypus update 0.8.1 to 0.8.1.1 (this only fixes the reported Platypus version number in the VCF)
   - Added conda environment
@@ -188,7 +200,7 @@ TBD
   - Neutral refactoring in `indelCalling.sh`
   - Bugfix: JSON syntax for "file"
 
-* Version update to 1.2.177-4 (includes development versions 1.2.177-1 to -3)
+* Version update to 1.2.177-4 (includes development versions 1.2.177-1 to -3) (Bug since 1.0.167)
 
   - Roddy 3.0 support
   - Updated COWorkflows base plugin from 1.2.59 to 1.2.76
@@ -196,26 +208,26 @@ TBD
   - Bugfix in `indel_extractor_v1.pl` concerning ncRNA_exonic and ncRNA_splicing annotations for somatic calls.
   - Added `runTindo` cvalue
 
-* Version update to 1.0.176-10 (=1.2.177-1)
+* Version update to 1.0.176-10 (=1.2.177-1) (Bug since 1.0.167)
 
   - Added right and bottom border features to `TiN_canopyBasedClustering.R`
   - Version is not backwards compatible
 
-* Version update to 1.0.176-9 (=1.0.177)
+* Version update to 1.0.176-9 (=1.0.177) (Bug since 1.0.167)
 
   - Fix of a bug affecting versions 1.0.176 to 1.0.176-8 that results in higher false positive rate.
 
-* Version update to 1.0.176
+* Version update to 1.0.176 (Bug since 1.0.167)
 
   - SNVs calling made default.
   - Swapchecker - checks for tumor/control swap from the same PID.
   - TiNDA - Tumor in normal detection analysis, using Canopy's EM-clustering algorithm.
 
-* Version update to 1.0.168
+* Version update to 1.0.168 (Bug since 1.0.167)
 
   - Further checks for the platypus indel calling step are introduced. A zgrep will be performed, together with a linecount to see if there are any faulty lines in the raw vcf file.
-  
-* Version update to 1.0.167
+
+* Version update to 1.0.167 (Bug 1.0.167)
 
   - Note that commit e8d8fc27 _introduced_ a bug. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ The following are older versions of the workflow on which no further development
 * Version update to 1.0.167 (<a id="column-bug"></a>Column bug)
 
   - Background: Platypus always orders the columns alpha-numerically. In our data, usually sample ID for the control is alpha-numerically smaller than that for the tumor, e.g., control/normal/blood < tumor/metastasis. Only for the sample pairs where tumor ID comes before the control (e.g. 'cell_line' < 'control'), the tumor genotype columns come before the control column in the raw VCF. This column swap was accounted for in the workflow code while detecting the somatic variants and control and, if needed, it swapped the columns. 
-    Bug: The commit e8d8fc27, which replaced the Perl script with the Python script, introduced a bug that replaced changed the names of the columns in the 10th & 11th columns with the unsorted labels, but left the data in the order created by Platypus.
+    Bug: The commit e8d8fc27, which replaced the Perl script with the Python script, introduced a bug that replaced the names of the columns in the 10th & 11th columns with the unsorted labels, but left the data in the order created by Platypus. Consequently, if Platypus reordered the columns and the script reused the unordered labels, the labels are swapped.
     > NOTE: This bug has no influence on the list of reported indels, and all somatic indels are correct. Only the genotype data are in the wrong columns.
 
 * Version update to 1.0.161

--- a/README.md
+++ b/README.md
@@ -95,53 +95,53 @@ Currently, the following versions are run in our production system. In all of th
 The following are older versions of the workflow on which no further development will take place.
 
 
-* Version update to 3.0.0 (2.5.0-deprecated) (Bug since 1.0.167)
+* Version update to 3.0.0 (2.5.0-deprecated) (Column bug since 1.0.167)
 
   - Major: Added a local control generated from ~1k WES samples
   - Deprecated version-tag 2.5.0 because this is actually a major-level change.
 
-* Version update to 2.4.3 (Bug since 1.0.167)
+* Version update to 2.4.3 (Column bug since 1.0.167)
 
   - Bugfix: `platypusIndelAnnotation.sh` now checks output of annovar execution for error code != 0. Without this the workflow will continue even if annovar throws an exception.
 
-* Version update to 2.4.2 (Bug since 1.0.167)
+* Version update to 2.4.2 (Column bug since 1.0.167)
 
   - Fixed missed annotations due to unsorted VCF
   
-* Version update to 2.4.1 (Bug since 1.0.167)
+* Version update to 2.4.1 (Column bug since 1.0.167)
 
   - Create __non-empty__ sample swap JSON even if less than 50 germline variants
   - More error-robust IO in sample swap TINDA Perl script
 
-* Version update to 2.4.0 (Bug since 1.0.167)
+* Version update to 2.4.0 (Column bug since 1.0.167)
 
   - Bugfix: Casting error in canopy-based clustering R code
   - Bugfix: Create warning PDF with text if number of to-be-merged PDFs is too large or zero, plus fix one-off bug
   - Exit 0 instead of != 0, if less then 50 germline variants
 
-* Version update 2.3.0 (Bug since 1.0.167)
+* Version update 2.3.0 (Column bug since 1.0.167)
 
   - Added `isNoControlWorkflow` variable and make FILTER_database work with it
   - Removed usage of ExAC from filtering, gnomAD includes ExAC
   - Report only exact matches for database annotation
   
-* Version update to 2.2.1 (Bug since 1.0.167)
+* Version update to 2.2.1 (Column bug since 1.0.167)
 
   - Stability improvement Perl to protect against I/O errors
-  - Write text PDf upon empty and too many indels
+  - Write text PDF upon empty and too many indels
 
-* Version update to 2.2.0 (Bug since 1.0.167)
+* Version update to 2.2.0 (Column bug since 1.0.167)
 
   - Upgrade from [COWorkflowsBasePlugin](https://github.com/DKFZ-ODCF/COWorkflowsBasePlugin) 1.1.0 to 1.4.1
 
-* Version update to 2.1.0-2 (Bug since 1.0.167)
+* Version update to 2.1.0-2 (Column bug since 1.0.167)
 
   - Fixed FILENAME_ parameter
   - Executability check for `REFERENCE_GENOME` variable (file accessible from submission host)
   - Fixed reported version.
   - Code cleanup in `annotate_vcf.pl`
 
-* Version update to 2.1.0-1 (Bug since 1.0.167)
+* Version update to 2.1.0-1 (Column bug since 1.0.167)
 
   - Added gnomAD exomes
   - Added local controls
@@ -149,15 +149,15 @@ The following are older versions of the workflow on which no further development
   - Check REF_genome for BAM files
   - Check BAM file readability
 
-* Version update to 2.0.0-2 (Bug since 1.0.167)
+* Version update to 2.0.0-2 (Column bug since 1.0.167)
 
   - Restricting screenshot generation to 100
 
-* Version update to 2.0.0-1 (Bug since 1.0.167)
+* Version update to 2.0.0-1 (Column bug since 1.0.167)
 
   - README update
   
-* Version update to 2.0.0 (Bug since 1.0.167)
+* Version update to 2.0.0 (Column bug since 1.0.167)
 
   - TiNDA workflow was updated
     - Two local controls are removed, and a new local control created from ~3000 WGS platypus variant calls were added.
@@ -167,32 +167,32 @@ The following are older versions of the workflow on which no further development
     - Temporary TiNDA files are cleaned up
     - TiNDA will stop if there are less than 50 rare germline variants
 
-* Version update to 1.3.0 (Bug since 1.0.167)
+* Version update to 1.3.0 (Column bug since 1.0.167)
 
   - Added `tumorSample` and `controlSample` variables to job environments. These can also be used in output file paths.
 
-* Version update to 1.2.178 (Bug since 1.0.167)
+* Version update to 1.2.178 (Column bug since 1.0.167)
 
   - Including gnomAD exomes and genomes for nocontrol workflow filtering.
   - Adding gnomAD files for no-control workflow.
   - Updated from COWorkflowsBasePlugin:1.0.3 to COWorkflowsBasePlugin:1.1.0.
 
-* Version update to 1.2.177-8 (=1.2.182) (Bug since 1.0.167)
+* Version update to 1.2.177-8 (=1.2.182) (Column bug since 1.0.167)
 
   - major: Changed `GERMLINE_AVAILABLE` with allowed values 0 and 1 to `isNoControlWorkflow` with allowed values "false" and "true".
   - minor: Update to from COWorkflows:1.2.59 to COWorkflowsBasePlugin:1.0.3.
   - minor: Added writing TiN classification to the VCF file.
   - Note that the version may report itself as 1.2.182 according to the `versionInfo.txt`.
 
-* Version update to 1.2.177-7 (Bug since 1.0.167)
+* Version update to 1.2.177-7 (Column bug since 1.0.167)
 
   - patch: Fix problem with dealing with empty result files in `indelCalling.sh`.
   
-* Version update to 1.2.177-6 (Bug since 1.0.167)
+* Version update to 1.2.177-6 (Column bug since 1.0.167)
 
   - Removed a `umask` from `checkSampleSwap_TiN.sh`.
 
-* Version update to 1.2.177-5 (Bug since 1.0.167)
+* Version update to 1.2.177-5 (Column bug since 1.0.167)
 
   - Platypus update 0.8.1 to 0.8.1.1 (this only fixes the reported Platypus version number in the VCF)
   - Added conda environment
@@ -200,36 +200,41 @@ The following are older versions of the workflow on which no further development
   - Neutral refactoring in `indelCalling.sh`
   - Bugfix: JSON syntax for "file"
 
-* Version update to 1.2.177-4 (includes development versions 1.2.177-1 to -3) (Bug since 1.0.167)
+* Version update to 1.2.177-4 (includes development versions 1.2.177-1 to -3) (Column bug since 1.0.167)
 
   - Roddy 3.0 support
   - Updated COWorkflows base plugin from 1.2.59 to 1.2.76
   - Fixed reported version
   - Bugfix in `indel_extractor_v1.pl` concerning ncRNA_exonic and ncRNA_splicing annotations for somatic calls.
-  - Added `runTindo` cvalue
+  - Added `runTinda` cvalue
 
-* Version update to 1.0.176-10 (=1.2.177-1) (Bug since 1.0.167)
+* Version update to 1.0.177-2 (Column bug since 1.0.167)
+
+  - Bugfix ncRNA file
+  - Allow toggling on/off of Tinda
+
+* Version update to 1.0.176-10 (=1.0.177-1) (Column bug since 1.0.167)
 
   - Added right and bottom border features to `TiN_canopyBasedClustering.R`
   - Version is not backwards compatible
 
-* Version update to 1.0.176-9 (=1.0.177) (Bug since 1.0.167)
+* Version update to 1.0.176-9 (=1.0.177) (Column bug since 1.0.167)
 
   - Fix of a bug affecting versions 1.0.176 to 1.0.176-8 that results in higher false positive rate.
 
-* Version update to 1.0.176 (Bug since 1.0.167)
+* Version update to 1.0.176 (Column bug since 1.0.167)
 
   - SNVs calling made default.
   - Swapchecker - checks for tumor/control swap from the same PID.
   - TiNDA - Tumor in normal detection analysis, using Canopy's EM-clustering algorithm.
 
-* Version update to 1.0.168 (Bug since 1.0.167)
+* Version update to 1.0.168 (Column bug since 1.0.167)
 
   - Further checks for the platypus indel calling step are introduced. A zgrep will be performed, together with a linecount to see if there are any faulty lines in the raw vcf file.
 
-* Version update to 1.0.167 (Bug 1.0.167)
+* Version update to 1.0.167 (Column bug 1.0.167)
 
-  - Note that commit e8d8fc27 _introduced_ a bug. Output VCF with swapped control and tumor genotype columns if they are in the 11th and 10th column respectively.
+  - Note that commit e8d8fc27 _introduced_ a bug that caused the labels of the control and tumor genotype columns (10 & 11) to be swapped into alphabetical order, but left the data in the original order. The root cause of the bug is that Platypus reorders these columns alphabetically, but that this was not accounted for in the workflow code. The bug has no influence on the list of reported indels. This means that all somatic indels are correct. Only samples in which the alphabetical order of the tumor sample is before that of the control sample (e.g. cell_line < control).
 
 * Version update to 1.0.161
 


### PR DESCRIPTION
* added few information for some releases
* moved newest versions from currently maintained branches to the top
* indicated versions affected by the 1.0.167 column-swap bug.

As far as I remember that column-swap bug was not classified as severe, right @NagaComBio? This was because the columns were only used by very few people.