### PR TITLE
Fix column swap bug for nocontrol workflow

### DIFF
--- a/resources/analysisTools/indelCallingWorkflow/confidenceAnnotation_Indels.py
+++ b/resources/analysisTools/indelCallingWorkflow/confidenceAnnotation_Indels.py
@@ -534,7 +534,8 @@ def main(args):
             entries[2] = dbsnp_id + "_" + dbsnp_pos
 
         ### Change the columns to make sure control is always in column 9 and tumor in column 10 (0 based)
-        entries[9], entries[10] = entries[header_indices["CONTROL_COL"]], entries[header_indices["TUMOR_COL"]]
+        if not args.no_control:
+            entries[9], entries[10] = entries[header_indices["CONTROL_COL"]], entries[header_indices["TUMOR_COL"]]
 
         print '\t'.join(entries)
 


### PR DESCRIPTION
The control, tumor column swap bug fix resulted in a bug for the nocontrol workflow. The region_condifence column is substituted for the DBSNP column and swaped with the tumor column. This is fixed with this commit.

@vinjana Should we fix this also in the release branches, though OTP doesn't run the nocontrol workflow.