### PR TITLE
Local control annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ TBD
 
 * Version update to 2.4.1-2
   
-  * Add local control annotations via deepAnnotation pipe
+  * patch: Adding two columns of local control annotations (WGS, WES) via deepAnnotation pipe. The annotations will be used for the reduced coverage filters in the downstream workflows.
 
 * Version update to 2.4.1-1
   

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ TBD
 
 # Changelist
 
+* Version update to 2.4.1-2
+  
+  * Add local control annotations via deepAnnotation pipe
+
+* Version update to 2.4.1-1
+  
+  * Column swap bug fix 
+  
 * Version update to 2.4.1
 
   * Create __non-empty__ sample swap JSON even if less than 50 germline variants

--- a/resources/configurationFiles/analysisIndelCalling.xml
+++ b/resources/configurationFiles/analysisIndelCalling.xml
@@ -184,6 +184,8 @@
             <cvalue name='COSMIC' value='${hg19DatabasesDirectory}/COSMIC/Cosmic_v77_hg19_coding_SNVs.bed.gz:7,8,9:1' type="path"/>
             <cvalue name='ENCODE_DNASE' value='${hg19DatabaseUCSCDirectory}/Sept2013/UCSC_27Sept2013_DNase_cluster_V2.bed.gz' type="path"/>
             <cvalue name='ENCODE_TFBS' value='${hg19DatabaseUCSCDirectory}/Sept2013/UCSC_27Sept2013_wgEncodeRegTfbsClusteredV3.bed.gz' type="path"/>
+            <cvalue name='RCC_LocalControlAF_WGS' value='${hg19DatabasesDirectory}/LocalControls/ExclusionList_2019/MPsnvs_PLindels/ExclusionList_2019_HIPO-PCAWG_MP_PL_WGS.INDELs.AFgt1.vcf.gz::4:--reportMatchType' type="path"/>
+            <cvalue name='RCC_LocalControlAF_WES' value='${hg19DatabasesDirectory}/LocalControls/ExclusionList_2019/MPsnvs_PLindels/ExclusionList_2019_H021_MP_PL_WES.INDELs.AFgt1.vcf.gz::4:--reportMatchType' type="path"/>
         </configurationValueBundle>
 
     </configurationvalues>


### PR DESCRIPTION
- Local control annotation for 2.4.1 release. 
- This release already uses the same local control WGS annotation, but with a different column name. To keep the same column names between the RCC versions, I have added both WES and WGS local control here.